### PR TITLE
Change AndroidActivity getter

### DIFF
--- a/Appium/MainForm/Model.cs
+++ b/Appium/MainForm/Model.cs
@@ -19,7 +19,7 @@ namespace Appium.MainWindow
         /// <summary>android activity</summary>
         public string AndroidActivity
         {
-            get { return this._View.AndroidActivityCheckbox.Text; }
+            get { return this._View.AndroidActivityTextBox.Text; }
             set
             {
                 Appium.Properties.Settings.Default.AndroidActivity = value;


### PR DESCRIPTION
This is literally fatal to the application startup.  Before this change, `--android-activity Activity:` was being sent through, regardless of the Activity input.
