### PR TITLE
Issue35 fix

### DIFF
--- a/Appium.Tests/TestAppiumServerConfiguration.cs
+++ b/Appium.Tests/TestAppiumServerConfiguration.cs
@@ -17,7 +17,7 @@ namespace Appium.Tests
 		[Test]
 		public void TestFullResetNoResetMutualExclusivity()
 		{
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.PerformFullAndroidReset = true;
 			settings.ResetApplicationState = false;
 
@@ -33,7 +33,7 @@ namespace Appium.Tests
 		[Test]
 		public void TestAllDeveloperSettingsIgnoredWhenDevModeDisabled()
 		{
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.UseDeveloperMode = false;
 			settings.UseExternalNodeJSBinary = true;
 			settings.ExternalNodeJSBinary = "testNodeJs";
@@ -55,7 +55,7 @@ namespace Appium.Tests
 		public void TestDeveloperModeExternalNodeJsLibraryIsUsed()
 		{
 			string testNodeJs = "testNodeJs"; 
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.UseDeveloperMode = true;
 			settings.UseExternalNodeJSBinary = true;
 			settings.ExternalNodeJSBinary = testNodeJs;
@@ -74,7 +74,7 @@ namespace Appium.Tests
 		public void TestDeveloperModeExternalAppiumPackageIsUsed()
 		{
 			string test = "app";
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.UseDeveloperMode = true;
 			settings.UseExternalAppiumPackage = true;
 			settings.ExternalAppiumPackage = test;
@@ -93,7 +93,7 @@ namespace Appium.Tests
 		public void TestDeveloperModeNodeJsDebuggingPortUsage()
 		{
 			uint port = 1234;
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.UseDeveloperMode = true;
 			settings.UseNodeJSDebugging = true;
 			settings.NodeJSDebugPort = port;
@@ -112,7 +112,7 @@ namespace Appium.Tests
 		[Test]
 		public void TestDeveloperModeBreakOnAppStartUsage()
 		{
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.UseDeveloperMode = true;
 			settings.BreakOnApplicationStart = true;
 
@@ -130,7 +130,7 @@ namespace Appium.Tests
 		public void TestAndroidActivityUsage()
 		{
 			string test = "testActivity";
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.AndroidActivity = test;
 
 			AppiumServerRunnerMock setup = new AppiumServerRunnerMock(NODE_RUNNER, WORKING_DIR, settings);
@@ -150,7 +150,7 @@ namespace Appium.Tests
 		public void TestAndroidPackageUsage()
 		{
 			string test = "testPackage";
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.AndroidPackage = test;
 
 			AppiumServerRunnerMock setup = new AppiumServerRunnerMock(NODE_RUNNER, WORKING_DIR, settings);
@@ -170,7 +170,7 @@ namespace Appium.Tests
 		public void TestLaunchAVDUsage()
 		{
 			string test = "AVD";
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.AVDToLaunch = test;
 
 			AppiumServerRunnerMock setup = new AppiumServerRunnerMock(NODE_RUNNER, WORKING_DIR, settings);
@@ -190,7 +190,7 @@ namespace Appium.Tests
 		public void TestAndroidWaitActivityUsage()
 		{
 			string test = "wait";
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.AndroidWaitActivity = test;
 
 			AppiumServerRunnerMock setup = new AppiumServerRunnerMock(NODE_RUNNER, WORKING_DIR, settings);
@@ -210,7 +210,7 @@ namespace Appium.Tests
 		public void TestAndroidDeviceReadyTimeoutUsage()
 		{
 			uint test = 1234;
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.AndroidDeviceReadyTimeout = test;
 
 			AppiumServerRunnerMock setup = new AppiumServerRunnerMock(NODE_RUNNER, WORKING_DIR, settings);
@@ -229,7 +229,7 @@ namespace Appium.Tests
 		[Test]
 		public void TestQuietLoggingUsage()
 		{
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 
 			AppiumServerRunner setup = new AppiumServerRunner(NODE_RUNNER, WORKING_DIR, settings);
 
@@ -246,7 +246,7 @@ namespace Appium.Tests
 		[Test]
 		public void TestKeepArtifactsUsage()
 		{
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 
 			AppiumServerRunner setup = new AppiumServerRunner(NODE_RUNNER, WORKING_DIR, settings);
 
@@ -263,7 +263,7 @@ namespace Appium.Tests
 		[Test]
 		public void TestPrelauchApplicationUsage()
 		{
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 
 			AppiumServerRunner setup = new AppiumServerRunner(NODE_RUNNER, WORKING_DIR, settings);
 
@@ -282,7 +282,7 @@ namespace Appium.Tests
 		{
 			string ipAddr = "1.0.0.0";
 			uint port = 1234;
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			settings.IPAddress = ipAddr;
 			settings.Port = port;
 

--- a/Appium.Tests/TestMainFormModel.cs
+++ b/Appium.Tests/TestMainFormModel.cs
@@ -21,7 +21,7 @@ namespace Appium.Tests
 		public void TestSetupAppPathChangesSettingsAndNotifies()
 		{
 			// setup
-			DefaultAppiumServerSettings settings = new DefaultAppiumServerSettings();
+			DefaultAppiumAppSettings settings = new DefaultAppiumAppSettings();
 			Model mainModel = new Model(null, settings);
 			List<string> events = new List<string>();
 			mainModel.PropertyChanged += delegate(object s, PropertyChangedEventArgs e)

--- a/Appium/App.config
+++ b/Appium/App.config
@@ -97,6 +97,9 @@
             <setting name="UseAndroidDeviceReadyTimeout" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="InspectorDeviceCapability" serializeAs="String">
+                <value>android</value>
+            </setting>
         </Appium.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Appium/Appium.csproj
+++ b/Appium/Appium.csproj
@@ -80,11 +80,13 @@
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>
     <Compile Include="MainForm\Model.cs" />
+    <Compile Include="Models\Capability\Device.cs" />
+    <Compile Include="Models\DefaultAppiumAppSettings.cs" />
     <Compile Include="Models\Inspector\INode.cs" />
     <Compile Include="Models\Inspector\UIAutomatorNode.cs" />
+    <Compile Include="Models\IAppiumAppSettings.cs" />
     <Compile Include="Models\Server\AppiumServerArgument.cs" />
     <Compile Include="Models\AppiumServerRunner.cs" />
-    <Compile Include="Models\DefaultAppiumServerSettings.cs" />
     <Compile Include="Models\Server\BreakOnAppStartArgument.cs" />
     <Compile Include="Models\Server\AppiumServerStringArgument.cs" />
     <Compile Include="Models\Server\ApplicationPathArgument.cs" />

--- a/Appium/AutomapperConfiguration.cs
+++ b/Appium/AutomapperConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Appium.Models;
 using AutoMapper;
+using Appium.Models.Capability;
 
 namespace Appium
 {
@@ -14,16 +15,23 @@ namespace Appium
 		/// </summary>
 		public static void Configure()
 		{
-			Mapper.CreateMap<Appium.Properties.Settings,IAppiumServerSettings>()
+			Mapper.CreateMap<Appium.Properties.Settings,IAppiumAppSettings>()
 				.ForMember(d => d.AVDToLaunch, opt => opt.MapFrom(s => s.AVD))
 				.ForMember(d => d.IPAddress, opt => opt.MapFrom(s => s.ServerAddress))
 				.ForMember(d => d.Port, opt => opt.MapFrom(s => s.ServerPort))
 				.ForMember(d => d.UseDeveloperMode, opt => opt.MapFrom(s => s.DeveloperMode))
+				.ForMember(d => d.InspectorDeviceCapability, opt => opt.ResolveUsing(s => {
+					Device srcDevice;
+					if (Enum.TryParse<Device>(s.InspectorDeviceCapability, out srcDevice))
+						return srcDevice;
+					return Device.android;
+				}))
 				.ReverseMap()
 				.ForMember(d => d.AVD, opt => opt.MapFrom(s => s.AVDToLaunch))
 				.ForMember(d => d.ServerAddress, opt => opt.MapFrom(s => s.IPAddress))
 				.ForMember(d => d.ServerPort, opt => opt.MapFrom(s => s.Port))
-				.ForMember(d => d.DeveloperMode, opt => opt.MapFrom(s => s.UseDeveloperMode));
+				.ForMember(d => d.DeveloperMode, opt => opt.MapFrom(s => s.UseDeveloperMode))
+				.ForMember(d => d.InspectorDeviceCapability, opt => opt.MapFrom(s => s.InspectorDeviceCapability.ToString()));
 						
 		} 
 	}

--- a/Appium/InspectorWindow/InpsectorForm.cs
+++ b/Appium/InspectorWindow/InpsectorForm.cs
@@ -33,7 +33,9 @@ namespace Appium.InspectorWindow
 		{
 			try
 			{
-				ICapabilities capabilities = new DesiredCapabilities();
+				Dictionary<string, object> capsDef = new Dictionary<string, object>();
+				capsDef.Add("device", _Model.Settings.InspectorDeviceCapability.ToString());
+				ICapabilities capabilities = new DesiredCapabilities(capsDef);
 				_Driver = new ScreenshotRemoteWebDriver(new Uri("http://" + this._Model.IPAddress + ":" + this._Model.Port.ToString() + "/wd/hub"), capabilities);
 				// add increased timeout for inspector connection
 				Dictionary<string, int> args = new Dictionary<string, int>();
@@ -58,6 +60,11 @@ namespace Appium.InspectorWindow
 			DOMTreeView.Nodes.Clear();
 			_SetScreenshot();
 			string pagesource = _Driver.PageSource;
+			if (String.IsNullOrEmpty(pagesource))
+			{
+				MessageBox.Show("Empty page source returned, unable to create hierarchy tree.","Appium Warning",MessageBoxButtons.OK,MessageBoxIcon.Warning);
+				return;
+			}
 			Root rootNode = JsonConvert.DeserializeObject<Root>(pagesource);
 			PopulateTree(rootNode.Hierarchy, DOMTreeView.Nodes);
 		}

--- a/Appium/MainForm/MainForm.cs
+++ b/Appium/MainForm/MainForm.cs
@@ -19,7 +19,7 @@ namespace Appium.MainWindow
         public MainForm()
         {
             // initialize
-			_Model = new Model(this, new Models.DefaultAppiumServerSettings());
+			_Model = new Model(this, new Models.DefaultAppiumAppSettings());
 			//_Model = new Model(this);
             InitializeComponent();
 			this.modelBindingSource.DataSource = _Model;

--- a/Appium/MainForm/Model.cs
+++ b/Appium/MainForm/Model.cs
@@ -10,7 +10,7 @@ namespace Appium.MainWindow
 	{
 		/// <summary>constructor</summary>
 		/// <param name="form">main form</param>
-		public Model(MainForm form, IAppiumServerSettings settings)
+		public Model(MainForm form, IAppiumAppSettings settings)
 		{
 			this._View = form;
 			_Settings = settings;
@@ -18,9 +18,9 @@ namespace Appium.MainWindow
 			_Settings.Load();
 		}
 
-		private IAppiumServerSettings _Settings;
+		private IAppiumAppSettings _Settings;
 		//TODO this is here just to test currently refactored functionality in steps, in the future, we should not allow direct access to settings
-		public IAppiumServerSettings Settings { get { return _Settings; } }
+		public IAppiumAppSettings Settings { get { return _Settings; } }
 
 		/// <summary>main form</summary>
 		public MainForm _View;

--- a/Appium/Models/Capability/Device.cs
+++ b/Appium/Models/Capability/Device.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Appium.Models.Capability
+{
+	public enum Device
+	{
+		android,
+		firefoxos,
+		selendroid
+	}
+}

--- a/Appium/Models/DefaultAppiumAppSettings.cs
+++ b/Appium/Models/DefaultAppiumAppSettings.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using AutoMapper;
+using Appium.Models.Capability;
 
 namespace Appium.Models
 {
-	public class DefaultAppiumServerSettings : IAppiumServerSettings
+	public class DefaultAppiumAppSettings : IAppiumAppSettings
 	{
 		public string ApplicationPath { get; set; }
 
@@ -63,12 +64,14 @@ namespace Appium.Models
 
 		public bool UseNodeJSDebugging { get; set; }
 
+		public Device InspectorDeviceCapability { get; set; }
+
 		/// <summary>
 		/// Saves Appium Server settings into default settings file
 		/// </summary>
 		public void Save()
 		{
-			Mapper.Map<IAppiumServerSettings, Appium.Properties.Settings>(this, Appium.Properties.Settings.Default);
+			Mapper.Map<IAppiumAppSettings, Appium.Properties.Settings>(this, Appium.Properties.Settings.Default);
 			Appium.Properties.Settings.Default.Save();
 		}
 
@@ -77,7 +80,7 @@ namespace Appium.Models
 		/// </summary>
 		public void Load()
 		{
-			Mapper.Map<Appium.Properties.Settings,IAppiumServerSettings>(Appium.Properties.Settings.Default,this);
+			Mapper.Map<Appium.Properties.Settings,IAppiumAppSettings>(Appium.Properties.Settings.Default,this);
 		}
 	}
 }

--- a/Appium/Models/IAppiumAppSettings.cs
+++ b/Appium/Models/IAppiumAppSettings.cs
@@ -1,0 +1,8 @@
+﻿using Appium.Models.Capability;
+namespace Appium.Models
+{
+	public interface IAppiumAppSettings : IAppiumServerSettings
+	{
+		Device InspectorDeviceCapability { get; set; }
+	}
+}

--- a/Appium/PreferencesWindow/PreferencesForm.Designer.cs
+++ b/Appium/PreferencesWindow/PreferencesForm.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace Appium.PreferencesWindow
+﻿using Appium.Models.Capability;
+using System;
+namespace Appium.PreferencesWindow
 {
     partial class PreferencesForm
     {
@@ -34,6 +36,7 @@
 			this.ExternalAppiumPackageBrowse = new System.Windows.Forms.Button();
 			this.ExternalNodeJSBinaryBrowseButton = new System.Windows.Forms.Button();
 			this.ExternalAppiumPackageTextBox = new System.Windows.Forms.TextBox();
+			this.preferencesPModelBindingSource = new System.Windows.Forms.BindingSource(this.components);
 			this.ExternalNodeJSBinaryTextBox = new System.Windows.Forms.TextBox();
 			this.NodeJSDebugPortPicker = new System.Windows.Forms.NumericUpDown();
 			this.BreakOnApplicationStartCheckbox = new System.Windows.Forms.CheckBox();
@@ -46,10 +49,13 @@
 			this.KeepArtifactsCheckbox = new System.Windows.Forms.CheckBox();
 			this.QuietLoggingCheckbox = new System.Windows.Forms.CheckBox();
 			this.CheckForUpdatesCheckbox = new System.Windows.Forms.CheckBox();
-			this.preferencesPModelBindingSource = new System.Windows.Forms.BindingSource(this.components);
+			this.InspectorSettingsGroupbox = new System.Windows.Forms.GroupBox();
+			this.CapabilityDeviceLabel = new System.Windows.Forms.Label();
+			this.InspectorDeviceCapabilityCombo = new System.Windows.Forms.ComboBox();
 			this.DeveloperSettingsGroupBox.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.NodeJSDebugPortPicker)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this.preferencesPModelBindingSource)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.NodeJSDebugPortPicker)).BeginInit();
+			this.InspectorSettingsGroupbox.SuspendLayout();
 			this.SuspendLayout();
 			// 
 			// DeveloperSettingsGroupBox
@@ -106,6 +112,10 @@
 			this.ExternalAppiumPackageTextBox.Name = "ExternalAppiumPackageTextBox";
 			this.ExternalAppiumPackageTextBox.Size = new System.Drawing.Size(167, 20);
 			this.ExternalAppiumPackageTextBox.TabIndex = 12;
+			// 
+			// preferencesPModelBindingSource
+			// 
+			this.preferencesPModelBindingSource.DataSource = typeof(Appium.PreferencesWindow.PreferencesPModel);
 			// 
 			// ExternalNodeJSBinaryTextBox
 			// 
@@ -244,15 +254,44 @@
 			this.CheckForUpdatesCheckbox.UseVisualStyleBackColor = true;
 			this.CheckForUpdatesCheckbox.CheckedChanged += new System.EventHandler(this.CheckForUpdatesCheckbox_CheckedChanged);
 			// 
-			// preferencesPModelBindingSource
+			// InspectorSettingsGroupbox
 			// 
-			this.preferencesPModelBindingSource.DataSource = typeof(Appium.PreferencesWindow.PreferencesPModel);
+			this.InspectorSettingsGroupbox.Controls.Add(this.CapabilityDeviceLabel);
+			this.InspectorSettingsGroupbox.Controls.Add(this.InspectorDeviceCapabilityCombo);
+			this.InspectorSettingsGroupbox.Location = new System.Drawing.Point(19, 283);
+			this.InspectorSettingsGroupbox.Name = "InspectorSettingsGroupbox";
+			this.InspectorSettingsGroupbox.Size = new System.Drawing.Size(431, 47);
+			this.InspectorSettingsGroupbox.TabIndex = 7;
+			this.InspectorSettingsGroupbox.TabStop = false;
+			this.InspectorSettingsGroupbox.Text = "Inspector Settings";
+			// 
+			// CapabilityDeviceLabel
+			// 
+			this.CapabilityDeviceLabel.AutoSize = true;
+			this.CapabilityDeviceLabel.Location = new System.Drawing.Point(7, 20);
+			this.CapabilityDeviceLabel.Name = "CapabilityDeviceLabel";
+			this.CapabilityDeviceLabel.Size = new System.Drawing.Size(129, 13);
+			this.CapabilityDeviceLabel.TabIndex = 1;
+			this.CapabilityDeviceLabel.Text = "Capability \"device\" to use";
+			// 
+			// InspectorDeviceCapabilityCombo
+			// 
+			this.InspectorDeviceCapabilityCombo.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.preferencesPModelBindingSource, "InspectorDeviceCapability", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+			this.InspectorDeviceCapabilityCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			this.InspectorDeviceCapabilityCombo.FormattingEnabled = true;
+			this.InspectorDeviceCapabilityCombo.Location = new System.Drawing.Point(177, 17);
+			this.InspectorDeviceCapabilityCombo.Name = "InspectorDeviceCapabilityCombo";
+			this.InspectorDeviceCapabilityCombo.Size = new System.Drawing.Size(121, 21);
+			this.InspectorDeviceCapabilityCombo.TabIndex = 0;
+
+			CustomInits();
 			// 
 			// PreferencesForm
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(463, 282);
+			this.ClientSize = new System.Drawing.Size(463, 332);
+			this.Controls.Add(this.InspectorSettingsGroupbox);
 			this.Controls.Add(this.DeveloperSettingsGroupBox);
 			this.Controls.Add(this.DeveloperModeCheckbox);
 			this.Controls.Add(this.PreLaunchApplicationCheckbox);
@@ -265,12 +304,19 @@
 			this.Text = "Appium Preferences";
 			this.DeveloperSettingsGroupBox.ResumeLayout(false);
 			this.DeveloperSettingsGroupBox.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.NodeJSDebugPortPicker)).EndInit();
 			((System.ComponentModel.ISupportInitialize)(this.preferencesPModelBindingSource)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.NodeJSDebugPortPicker)).EndInit();
+			this.InspectorSettingsGroupbox.ResumeLayout(false);
+			this.InspectorSettingsGroupbox.PerformLayout();
 			this.ResumeLayout(false);
 			this.PerformLayout();
 
         }
+
+		private void CustomInits()
+		{
+			this.InspectorDeviceCapabilityCombo.Items.AddRange(Enum.GetNames(typeof(Device)));
+		}
 
         #endregion
 
@@ -291,5 +337,8 @@
         private System.Windows.Forms.Button ExternalAppiumPackageBrowse;
         private System.Windows.Forms.Button ExternalNodeJSBinaryBrowseButton;
 		private System.Windows.Forms.BindingSource preferencesPModelBindingSource;
+		private System.Windows.Forms.GroupBox InspectorSettingsGroupbox;
+		private System.Windows.Forms.Label CapabilityDeviceLabel;
+		private System.Windows.Forms.ComboBox InspectorDeviceCapabilityCombo;
     }
 }

--- a/Appium/PreferencesWindow/PreferencesForm.cs
+++ b/Appium/PreferencesWindow/PreferencesForm.cs
@@ -7,7 +7,7 @@ namespace Appium.PreferencesWindow
     {
 		public PreferencesForm()
 		{
-			InitializeComponent();
+			InitializeComponent();			
 		}
 
         /// <summary>called when the browse button for external nodejs binary is clicked</summary>

--- a/Appium/PreferencesWindow/PreferencesPModel.cs
+++ b/Appium/PreferencesWindow/PreferencesPModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Appium.Models;
+using Appium.Models.Capability;
 
 
 namespace Appium.PreferencesWindow
@@ -9,10 +10,10 @@ namespace Appium.PreferencesWindow
 	/// </summary>
 	public class PreferencesPModel
 	{
-		private IAppiumServerSettings _Settings;
+		private IAppiumAppSettings _Settings;
 		private IPreferencesView _View;
 
-		public PreferencesPModel(IAppiumServerSettings settings, IPreferencesView view)
+		public PreferencesPModel(IAppiumAppSettings settings, IPreferencesView view)
 		{
 			_Settings = settings;
 			_View = view;
@@ -107,6 +108,15 @@ namespace Appium.PreferencesWindow
 		{
 			get { return _Settings.UseNodeJSDebugging; }
 			set	{ _Settings.UseNodeJSDebugging = value; }
+		}
+
+		/// <summary>
+		/// Capability to use when launching inspector
+		/// </summary>
+		public Device InspectorDeviceCapability
+		{
+			get { return _Settings.InspectorDeviceCapability;}
+			set { _Settings.InspectorDeviceCapability = value; }
 		}
 
 		public void OpenWindow()

--- a/Appium/Properties/Settings.Designer.cs
+++ b/Appium/Properties/Settings.Designer.cs
@@ -370,5 +370,17 @@ namespace Appium.Properties {
                 this["UseAndroidDeviceReadyTimeout"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("android")]
+        public string InspectorDeviceCapability {
+            get {
+                return ((string)(this["InspectorDeviceCapability"]));
+            }
+            set {
+                this["InspectorDeviceCapability"] = value;
+            }
+        }
     }
 }

--- a/Appium/Properties/Settings.settings
+++ b/Appium/Properties/Settings.settings
@@ -89,5 +89,8 @@
     <Setting Name="UseAndroidDeviceReadyTimeout" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="InspectorDeviceCapability" Type="System.String" Scope="User">
+      <Value Profile="(Default)">android</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
- added check for empty source returned from appium when constructing the
  hierarchy tree
- since appium 0.14.2 we need device to be passed in the capability
- added inspector device capability to Preferences form
