### PR TITLE
Clear Log action and Scroll to bottom

### DIFF
--- a/AppiumWPF/Dictionaries/Styles.xaml
+++ b/AppiumWPF/Dictionaries/Styles.xaml
@@ -11,7 +11,6 @@
 
     <!-- Default Style for CheckBox -->
     <Style
-        BasedOn="{StaticResource {x:Type CheckBox}}"
         TargetType="CheckBox">
         <Setter
             Property="FlowDirection"

--- a/AppiumWPF/MainWindow.xaml
+++ b/AppiumWPF/MainWindow.xaml
@@ -51,8 +51,13 @@
                 Visibility="Collapsed"
                 IsEnabled="False" />
             <!--Command="{Binding InspectorOpenCommand}" />-->
+
             <MenuItem
-                Name="btnLaunch"
+                HorizontalContentAlignment="Center"
+                Header="Clear Log"
+                ToolTip="Clear the output log"
+                Command="{Binding ClearOutputCommand}" />
+            <MenuItem
                 HorizontalContentAlignment="Center"
                 Width="60"
                 ToolTip="Launch the Appium Node Server"
@@ -96,7 +101,8 @@
                 Background="Black"
                 Height="Auto"
                 Margin="0"
-                Text="{Binding Output}" />
+                TargetUpdated="_ScrollToBottom"
+                Text="{Binding Output, NotifyOnTargetUpdated=True}" />
         </ScrollViewer>
     </DockPanel>
 </Window>

--- a/AppiumWPF/MainWindow.xaml.cs
+++ b/AppiumWPF/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using Appium.Views;
 using System;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace Appium
 {
@@ -20,6 +21,11 @@ namespace Appium
             DataContext = _VM;
         }
 
+        /// <summary>
+        /// Preference menu item clicked
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void PreferenceClick(object sender, RoutedEventArgs e)
         {
             Window win = new PreferenceWindow() { DataContext = _VM.PreferenceWindowVM };
@@ -28,12 +34,29 @@ namespace Appium
             {
                 win.ShowDialog();
             }
+       }
 
-        }
-
-        private void MenuItem_DragEnter(object sender, DragEventArgs e)
+        /// <summary>
+        /// Scroll to the bottom of the TextBlock
+        /// </summary>
+        /// <param name="sender">object who fired this event</param>
+        /// <param name="e">NOT USED</param>
+        private void _ScrollToBottom(object sender, System.Windows.Data.DataTransferEventArgs e)
         {
-
+            TextBlock tb;
+            ScrollViewer sv;
+            if (null == (tb = sender as TextBlock))
+            {
+                // do nothing
+            }
+            else if (null == (sv = tb.Parent as ScrollViewer))
+            {
+                // do nothing
+            }
+            else
+            {
+                sv.ScrollToBottom();
+            }
         }
     }
 }

--- a/AppiumWPF/ViewModels/MainWindowVM.cs
+++ b/AppiumWPF/ViewModels/MainWindowVM.cs
@@ -108,6 +108,12 @@ namespace Appium.ViewModels
             }
         }
 
+        private ICommand _ClearOutputCommand;
+        /// <summary>Open the File Dialog Command</summary>
+        public ICommand ClearOutputCommand
+        {
+            get { return _ClearOutputCommand ?? (_ClearOutputCommand = new RelayCommand(() => _ExecuteClearOutput())); }
+        }
         #endregion Commands
 
         /// <summary>The close action (should close the main window)</summary>
@@ -135,7 +141,6 @@ namespace Appium.ViewModels
                 }
             }
         }
-
         #endregion Public Properties
 
 
@@ -195,6 +200,12 @@ namespace Appium.ViewModels
             {
                 _AppiumEngine.Start();
             }
+        }
+
+        /// <summary>Clear the output string</summary>
+        private void _ExecuteClearOutput()
+        {
+            Output = string.Empty;
         }
         #endregion Execute Commands
 


### PR DESCRIPTION
Added a clear log button which will clear the output log in the main
appium window.
The output log also will automatically scroll to the bottom on updated
text.
