### PR TITLE
Fix #72 (Inspector Crash on 1.1.0 + 1.20)

### DIFF
--- a/AppiumWPF/Engine/ScreenshotRemoteWebDriver.cs
+++ b/AppiumWPF/Engine/ScreenshotRemoteWebDriver.cs
@@ -19,7 +19,18 @@ namespace Appium.Engine
         /// <returns>a screenshot</returns>
         public Screenshot GetScreenshot()
         {
-            Response screenshotResponse = this.Execute(DriverCommand.Screenshot, null);
+            Response screenshotResponse = null;
+
+            try
+            {
+                screenshotResponse = this.Execute(DriverCommand.Screenshot, null);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Error getting screenshot: {0}", e.Message);
+                return null;
+            }
+
             string base64 = screenshotResponse.Value.ToString();
             return new Screenshot(base64);
         }

--- a/AppiumWPF/Engine/SeleniumDriver.cs
+++ b/AppiumWPF/Engine/SeleniumDriver.cs
@@ -193,7 +193,15 @@ namespace Appium.Engine
             {
                 if (null != _Driver)
                 {
-                    data = _Driver.PageSource;
+                    try
+                    {
+                        data = _Driver.PageSource;
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine("Error getting page source: {0}", e.Message);
+                        return null;
+                    }
                 }
             }
             return data;
@@ -210,7 +218,12 @@ namespace Appium.Engine
             {
                 if (null != _Driver)
                 {
-                    retVal = ((ITakesScreenshot)_Driver).GetScreenshot().AsByteArray;
+                    Screenshot screenshot = ((ITakesScreenshot)_Driver).GetScreenshot();
+
+                    if (screenshot != null)
+                    {
+                        retVal = screenshot.AsByteArray;
+                    }
                 }
             }
             return retVal;

--- a/AppiumWPF/ViewModels/InspectorWindowVM.cs
+++ b/AppiumWPF/ViewModels/InspectorWindowVM.cs
@@ -158,6 +158,10 @@ namespace Appium.ViewModels
                 _RootNode.Add(vm);
                 FirePropertyChanged(() => RootNode);
             }
+            else
+            {
+                Message = "Error getting page source";
+            }
 
             if (firstTime)
             {
@@ -167,7 +171,16 @@ namespace Appium.ViewModels
 
             // grab the image
             ImageByteArray = _Driver.GetScreenshot();
-            Message = string.Format("Last updated on {0}", DateTime.Now);
+            if (ImageByteArray == null)
+            {
+                Message = "Error getting screenshot";
+            }
+            
+            // Show success message if the "Updating" message was not changed
+            if (Message.Equals("Updating"))
+            {
+                Message = string.Format("Last successfully updated on {0}", DateTime.Now);
+            }
         }
 
         /// <summary>Clean up all the root nodes</summary>


### PR DESCRIPTION
Added exception handlers to stop the client from crashing when an exception is raised when getting the page source, or a screenshot.

Still dependent upon https://github.com/appium/appium/issues/3162 for the fix for the cause of these exceptions.
