### PR TITLE
Added ability to Tap & SendKeys from the Inspector

### DIFF
--- a/AppiumWPF/AppiumWPF.csproj
+++ b/AppiumWPF/AppiumWPF.csproj
@@ -95,6 +95,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Converters\StringToVisibilityConverter.cs" />
+    <Compile Include="Models\Inspector\NodeTree.cs" />
     <Compile Include="Models\Server\AndroidBrowserArgument.cs" />
     <Compile Include="Models\Capability\Dictionaries.cs" />
     <Compile Include="Models\Inspector\AbstractNode.cs" />

--- a/AppiumWPF/Dictionaries/Styles.xaml
+++ b/AppiumWPF/Dictionaries/Styles.xaml
@@ -52,12 +52,6 @@
         BasedOn="{StaticResource {x:Type Button}}"
         TargetType="{x:Type Button}">
         <Setter
-            Property="Height"
-            Value="40" />
-        <Setter
-            Property="Width"
-            Value="40" />
-        <Setter
             Property="VerticalAlignment"
             Value="Center" />
         <Setter

--- a/AppiumWPF/Engine/SeleniumDriver.cs
+++ b/AppiumWPF/Engine/SeleniumDriver.cs
@@ -1,4 +1,5 @@
 ﻿using Appium.Models;
+using Appium.ViewModels;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Remote;
 using System;
@@ -228,6 +229,53 @@ namespace Appium.Engine
             }
             return retVal;
         }
+
+        public bool SendKeys(UIAutomatorNodeVM node, string value)
+        {
+            var button = _Driver.FindElementByName(node.Id);
+            try
+            {
+                button.SendKeys(value);
+                return true;
+            }
+            catch (Exception ex)
+            {    // Probably this item does not support keyboard input (the return from Appium 1.0.2 is too generic to recognise difference between unclickable and a system error).
+                Console.WriteLine("Failed to execute click : {0}", ex.Message);
+            }
+            return false;
+        }
+
+        public bool Tap(UIAutomatorNodeVM node)
+        {
+            var button = _Driver.FindElementByName(node.Id);
+            bool SuccessfullTap = false;
+            try
+            {
+                button.Click();
+                SuccessfullTap = true;
+            }
+            catch (Exception ex)
+            {    // It's probable this item does not support tapping.
+                Console.WriteLine("Failed to tap element : {0} (will try alternate method)", ex.Message);
+            }
+            if (!SuccessfullTap)
+            {
+                try
+                {
+                    // TODO: Alternate method of tapping.
+                    /*                    _Driver.Driver.Mouse.Click( button.Location.X);
+                                        d.SingleTap(button);
+                                        _ExecuteRefreshCommand();
+                                        SuccessfullTap = true;  */
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("Failed to use mouse to Tap element : {0}", ex.Message);
+                }
+            }
+            return SuccessfullTap;
+        }
+
 
         #endregion Public Methods
 

--- a/AppiumWPF/MainWindow.xaml
+++ b/AppiumWPF/MainWindow.xaml
@@ -68,86 +68,87 @@
             Margin="6,0,6,0"
             LastChildFill="False">
 
-            <!-- Left side of the Dock -->
-            <Button
+            <StackPanel Orientation="Horizontal" Height="80">
+                <!-- Left side of the Dock -->
+                <Button
                 Name="btnAndroidSettings"
                 DockPanel.Dock="Left"
                 ToolTip="Android Settings"
                 Command="{Binding AndroidSettingsCommand}">
-                <Image
+                    <Image
                     Source="{StaticResource androidImage}" />
-            </Button>
-            <Button
+                </Button>
+                <Button
                 Name="btnGeneralSettings"
                 DockPanel.Dock="Left"
                 ToolTip="General Settings"
                 Command="{Binding GeneralSettingsCommand}">
-                <Image
+                    <Image
                     Source="{StaticResource lightswitchImage}" />
-            </Button>
+                </Button>
 
-            <Button
+                <Button
                 Name="btnDeveloperSettings"
                 DockPanel.Dock="Left"
                 ToolTip="Developer Settings"
                 Command="{Binding DeveloperSettingsCommand}">
-                <Image
+                    <Image
                     Source="{StaticResource developerImage}" />
-            </Button>
-            <Button
+                </Button>
+                <Button
                 Name="btnAbout"
                 DockPanel.Dock="Left"
                 ToolTip="About"
                 Command="{Binding AboutCommand}">
-                <Image
+                    <Image
                     Source="{StaticResource aboutImage}" />
-            </Button>
-
+                </Button>
+            </StackPanel>
             <!-- Right side of the Dock -->
-            <Button
+            <StackPanel Orientation="Horizontal" Height="80" DockPanel.Dock="Right">
+                <Button
                 Name="btnLaunch"
-                DockPanel.Dock="Right"
                 Command="{Binding LaunchCommand}">
-                <Image>
-                    <Image.Style>
-                        <Style
+                    <Image>
+                        <Image.Style>
+                            <Style
                             TargetType="{x:Type Image}">
-                            <Style.Triggers>
-                                <DataTrigger
+                                <Style.Triggers>
+                                    <DataTrigger
                                     Binding="{Binding IsRunning}"
                                     Value="false">
-                                    <Setter
+                                        <Setter
                                         Property="Source"
                                         Value="{StaticResource rocketOnImage}" />
-                                    <Setter
+                                        <Setter
                                         Property="ToolTip"
                                         Value="Launch the Appium Node Server" />
-                                </DataTrigger>
-                                <DataTrigger
+                                    </DataTrigger>
+                                    <DataTrigger
                                     Binding="{Binding IsRunning}"
                                     Value="true">
-                                    <Setter
+                                        <Setter
                                         Property="Source"
                                         Value="{StaticResource stopImage}" />
-                                    <!--Value="{StaticResource rocketOffImage}" />-->
-                                    <Setter
+                                        <!--Value="{StaticResource rocketOffImage}" />-->
+                                        <Setter
                                         Property="ToolTip"
                                         Value="Stop the Appium Node Server" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Image.Style>
-                </Image>
-            </Button>
-            <Button
-                Name="btnInspector"
-                DockPanel.Dock="Right"
-                ToolTip="Inspector"
-                IsEnabled="{Binding IsInspectorWindowOpen, Converter={StaticResource inverseBoolConv}}"
-                Click="_InspectorClick">
-                <Image
-                    Source="{StaticResource infoImage}" />
-            </Button>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Image.Style>
+                    </Image>
+                </Button>
+                <Button
+                    Name="btnInspector"
+                    ToolTip="Inspector"
+                    IsEnabled="{Binding IsInspectorWindowOpen, Converter={StaticResource inverseBoolConv}}"
+                    Click="_InspectorClick">
+                    <Image
+                        Source="{StaticResource infoImage}" />
+                </Button>
+            </StackPanel>
 
         </DockPanel>
 

--- a/AppiumWPF/Models/Inspector/AbstractNode.cs
+++ b/AppiumWPF/Models/Inspector/AbstractNode.cs
@@ -46,6 +46,12 @@ namespace Appium.Models.Inspector
         public abstract string GetDetails();
 
         /// <summary>
+        /// Get Id (Label on Android?)
+        /// </summary>
+        /// <returns>node details</returns>
+        public abstract string GetNameId();
+
+        /// <summary>
         /// Returns a copied list of children
         /// </summary>
         /// <returns>copied list of children</returns>

--- a/AppiumWPF/Models/Inspector/INode.cs
+++ b/AppiumWPF/Models/Inspector/INode.cs
@@ -8,6 +8,7 @@ namespace Appium.Models.Inspector
 		string GetDisplayName();
 		List<INode> GetChildren();
 		string GetDetails();
+        string GetNameId();
         //Rectangle GetOutline();
 	}
 }

--- a/AppiumWPF/Models/Inspector/NodeTree.cs
+++ b/AppiumWPF/Models/Inspector/NodeTree.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.ObjectModel;
+using Appium.Engine;
+using Appium.Models;
+using Appium.Models.Inspector;
+using Appium.Utility;
+using Appium.ViewModels;
+using System.Windows;
+
+namespace Appium.Models.Inspector
+{
+    /// <summary>
+    /// This class wrapps the Node Tree view to allow us to extend it with utility functions
+    /// </summary>
+    public class NodeTree<T> : ObservableCollection<T>        // ObservableCollection
+    {
+        public NodeTree()
+        {
+        }
+    }
+}

--- a/AppiumWPF/Models/Inspector/UIAutomatorAndroidNode.cs
+++ b/AppiumWPF/Models/Inspector/UIAutomatorAndroidNode.cs
@@ -66,6 +66,15 @@ namespace Appium.Models.Inspector
         }
 
         /// <summary>
+        /// Gets the Name or Id of the Node (in this case the Id from Android)
+        /// </summary>
+        /// <returns></returns>
+        public override string GetNameId()     // Resource Id for Android
+        {
+            return _ResourceId;
+        }
+       
+        /// <summary>
         /// Details for the node
         /// </summary>
         /// <returns>detailed string representing this node</returns>

--- a/AppiumWPF/Models/Inspector/UIAutomatorAppleNode.cs
+++ b/AppiumWPF/Models/Inspector/UIAutomatorAppleNode.cs
@@ -60,6 +60,15 @@ namespace Appium.Models.Inspector
         }
 
         /// <summary>
+        /// Get Name or Id of the Node (Name for iOS, ResourceId for Android)
+        /// </summary>
+        /// <returns></returns>
+        public override string GetNameId()
+        {
+            return _Name;
+        }
+       
+        /// <summary>
         /// Get details for this node
         /// </summary>
         /// <returns>detailed string representing this node</returns>

--- a/AppiumWPF/ViewModels/UIAutomatorNodeVM.cs
+++ b/AppiumWPF/ViewModels/UIAutomatorNodeVM.cs
@@ -14,7 +14,7 @@ namespace Appium.ViewModels
     public class UIAutomatorNodeVM : BaseVM , IDisposable
     {
         #region Data
-        private readonly ObservableCollection<UIAutomatorNodeVM> _Children;
+        private readonly NodeTree<UIAutomatorNodeVM> _Children;
         private readonly INode _Model;
         private SelectionChangedEventHandler _EH;
         // flag: Has Dispose already been called?
@@ -32,7 +32,7 @@ namespace Appium.ViewModels
             _Model = node;
             _EH = eh;
             SelectionChanged += _EH;
-            _Children = new ObservableCollection<UIAutomatorNodeVM>();
+            _Children = new NodeTree<UIAutomatorNodeVM>();
             _LoadChildren();
         }
         #endregion // Constructors
@@ -49,7 +49,7 @@ namespace Appium.ViewModels
         /// <summary>
         /// Returns the logical child items of this object.
         /// </summary>
-        public ObservableCollection<UIAutomatorNodeVM> Children
+        public NodeTree<UIAutomatorNodeVM> Children
         {
             get { return _Children; }
         }
@@ -77,6 +77,12 @@ namespace Appium.ViewModels
         public string Name
         {
             get { return _Model.GetDisplayName(); }
+        }
+
+        ///<summary></summary>
+        public string Id
+        {
+            get { return _Model.GetNameId(); }
         }
 
         #endregion Properties

--- a/AppiumWPF/Views/InspectorWindow.xaml
+++ b/AppiumWPF/Views/InspectorWindow.xaml
@@ -154,20 +154,47 @@
             </DockPanel>
 
             <!-- Bottom Buttons -->
-            <!--
-            TODO: for future implementation
             <TabControl
-                Visibility="Collapsed"
+                Visibility="Visible"
                 Margin="4"
-                Height="80"
+                Height="Auto"
                 DockPanel.Dock="Bottom">
-                <TabItem
-                    Header="Touch" />
-                <TabItem
-                    Header="Text" />
-                <TabItem
-                    Header="Misc" />
-            </TabControl>-->
+                <TabItem Header="Touch">
+                    <Grid>
+                        <StackPanel>
+                            <DockPanel LastChildFill="False">
+                                <Button Command="{Binding TapCommand}">Tap</Button>
+                                <!--    
+                                TODO: For future implementation
+                                <Button Command="{Binding SwipeCommand}">Swipe</Button>
+                                <Button Command="{Binding ShakeCommand}">Shake</Button>     -->
+                            </DockPanel>
+                            <DockPanel LastChildFill="False" Visibility="Hidden">
+                                <Button>Precise Tap</Button>
+                                <Button>Scroll</Button>
+                            </DockPanel>
+                        </StackPanel>
+                    </Grid>
+                </TabItem>
+                <TabItem Header="Text" IsEnabled="True">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <DockPanel Grid.Row="0">
+                            <StackPanel>
+                                <TextBox Text="{Binding Path=TextInput, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            </StackPanel>
+                        </DockPanel>
+                        <StackPanel Grid.Row="1" HorizontalAlignment="Stretch" Orientation="Horizontal">
+                            <Button Command="{Binding SendKeysCommand}">Send Keys</Button>
+                        </StackPanel>
+                    </Grid>
+                </TabItem>
+                <TabItem Header="Locators" IsEnabled="False"></TabItem>
+                <TabItem Header="Misc" IsEnabled="False"></TabItem>
+            </TabControl>
             <DockPanel
                 DockPanel.Dock="Bottom"
                 LastChildFill="True">


### PR DESCRIPTION
The Inspector for the Mac has interaction buttons, I have enabled some of the interaction buttons for this project, specifically Tap and SendKeys. 

This patch also contains an update to the Styles.xaml to correct an issue with all buttons being sized to 40x40 causing UI resizing issues.

I have also updated the INode and abstract to add new functionality to expose the ResourceId (Android) or Name (iOS) for the purposes of Tap and SendKeys.

I have moved ObservableCollection<UIAutomatorNodeVM> into a class NodeTree<T> where T is UIAutomatorNodeVM. This was done so if the collection type needs modifying it only needs doing once. Also, shared common function can be placed in static methods.

The INode interface was updated to expose Id.
