### PR TITLE
Fixed hang when taskkill executes but no Appium running

### DIFF
--- a/installer/Appium-dot-exe.iss
+++ b/installer/Appium-dot-exe.iss
@@ -82,9 +82,8 @@ procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
   var ErrorCode: Integer;
   begin
     if CurUninstallStep = usUninstall then begin
-	ExecShelll('{cmd}', 'taskkill /F /T /IM Appium.exe');
 	ExecShelll('{app}\Appium.exe', '/d="{app}\node_modules"');
     end;
   end;
-
+  
 


### PR DESCRIPTION
Won't remove all components if Appium is running, which is a down side.  That could be fixed, but unfortunately I don't have any more time to devote to this.